### PR TITLE
Add DI via Dagger

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,7 @@
 apply plugin: 'com.android.application'
-
 apply plugin: 'kotlin-android'
-
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 29
@@ -27,6 +26,10 @@ android {
         abortOnError true
         warningsAsErrors true
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
@@ -38,6 +41,12 @@ dependencies {
 
     implementation 'com.airbnb.android:mvrx:2.0.0-alpha2'
     implementation "androidx.fragment:fragment-ktx:1.1.0"
+
+    implementation 'com.google.dagger:dagger:2.25.3'
+    kapt 'com.google.dagger:dagger-compiler:2.25.3'
+
+    compileOnly 'com.squareup.inject:assisted-inject-annotations-dagger2:0.5.2'
+    kapt 'com.squareup.inject:assisted-inject-processor-dagger2:0.5.2'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.truth:truth:1.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.wclausen.avocado">
 
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+
     <application
         android:name=".AvocadoApplication"
         android:allowBackup="true"

--- a/app/src/main/java/com/wclausen/avocado/AvocadoApplication.kt
+++ b/app/src/main/java/com/wclausen/avocado/AvocadoApplication.kt
@@ -3,11 +3,35 @@ package com.wclausen.avocado
 import android.app.Application
 import com.airbnb.mvrx.MvRx
 import com.airbnb.mvrx.MvRxViewModelConfigFactory
+import com.squareup.inject.assisted.dagger2.AssistedModule
+import dagger.Component
+import dagger.Module
+import javax.inject.Singleton
+
+@AssistedModule
+@Module(includes = [AssistedInject_AppAssistedModule::class])
+abstract class AppAssistedModule
+
+@Singleton
+@Component(modules = [AppAssistedModule::class])
+interface AppComponent {
+    fun inject(contactsFragment: ContactsFragment)
+}
 
 class AvocadoApplication : Application() {
+
+    lateinit var component: AppComponent
 
     override fun onCreate() {
         super.onCreate()
         MvRx.viewModelConfigFactory = MvRxViewModelConfigFactory(this)
+        component = DaggerAppComponent.create()
+        INSTANCE = this
+    }
+
+    companion object {
+        private lateinit var INSTANCE: AvocadoApplication
+
+        fun injector() = INSTANCE.component
     }
 }

--- a/app/src/main/java/com/wclausen/avocado/ContactsFragment.kt
+++ b/app/src/main/java/com/wclausen/avocado/ContactsFragment.kt
@@ -1,17 +1,46 @@
 package com.wclausen.avocado
 
 import com.airbnb.mvrx.*
+import com.squareup.inject.assisted.Assisted
+import com.squareup.inject.assisted.AssistedInject
+import com.wclausen.avocado.AvocadoApplication.Companion.injector
 import kotlinx.android.synthetic.main.contacts_fragment.*
+import javax.inject.Inject
 
 data class Person(val name: String)
 data class ContactsState(val contacts: Async<List<Person>> = Uninitialized) : MvRxState
 
-class ContactsViewModel(initialState: ContactsState) :
+class ContactsViewModel @AssistedInject constructor(@Assisted initialState: ContactsState, private val contactsRepo: ContactsRepository) :
     AvocadoViewModel<ContactsState>(initialState) {
+
+    @AssistedInject.Factory
+    interface Factory {
+        fun create(initialState: ContactsState): ContactsViewModel
+    }
+
+    companion object : MvRxViewModelFactory<ContactsViewModel, ContactsState> {
+        @JvmStatic
+        override fun create(
+            viewModelContext: ViewModelContext,
+            state: ContactsState
+        ): ContactsViewModel? {
+            val fragment =
+                (viewModelContext as FragmentViewModelContext).fragment<ContactsFragment>()
+            return fragment.viewModelFactory.create(state)
+        }
+    }
 }
 
-class ContactsFragment : BaseMvRxFragment(R.layout.contacts_fragment) {
+class ContactsFragment : InjectedFragment(R.layout.contacts_fragment) {
+    @Inject
+    lateinit var viewModelFactory: ContactsViewModel.Factory
     private val viewModel: ContactsViewModel by fragmentViewModel()
+
+    override fun inject() {
+        injector().inject(this)
+    }
+
+
     override fun invalidate() = withState(viewModel) { state ->
         helloWorld.text = state.contacts()?.get(0)?.name
     }

--- a/app/src/main/java/com/wclausen/avocado/ContactsRepository.kt
+++ b/app/src/main/java/com/wclausen/avocado/ContactsRepository.kt
@@ -1,0 +1,7 @@
+package com.wclausen.avocado
+
+import javax.inject.Inject
+
+class ContactsRepository @Inject constructor() {
+
+}

--- a/app/src/main/java/com/wclausen/avocado/InjectedFragment.kt
+++ b/app/src/main/java/com/wclausen/avocado/InjectedFragment.kt
@@ -1,0 +1,15 @@
+package com.wclausen.avocado
+
+import android.content.Context
+import com.airbnb.mvrx.BaseMvRxFragment
+
+abstract class InjectedFragment(layoutRes: Int) : BaseMvRxFragment(layoutRes) {
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        inject()
+    }
+
+    abstract fun inject()
+
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -11,4 +11,4 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-</FrameLayout>
+</LinearLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,15 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.6.0-rc01'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
+}
+
+plugins {
+    id "org.jetbrains.kotlin.kapt" version "1.3.61"
 }
 
 allprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 23 12:54:32 PST 2019
+#Tue Dec 24 13:40:53 PST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
Long journey to integrate MvRx with Dagger.

MvRx is tightly coupled to Android framework through Fragments and ViewModels. Android Framework is notoriously difficult to integrate with Dagger (in a nice way) because the framework instantiates the classes. When the framework instantiates the classes, DI has to happen after object creation, which complicates things.

I didn't want to move towards dagger-android because that has a lot of complexity (on top of DI's normal load) that I didn't think was worth it. As a result, I have to do manual field injection in fragments, which is not great, but not terrible.

Ultimately, I am trying to learn about MvRx and working with cutting edge Android libraries/components. This is an example where things aren't really smooth/intuitive. Experiencing the "cutting" part of the cutting edge.